### PR TITLE
feat: create formation grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.22.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -3350,6 +3351,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.0.tgz",
+      "integrity": "sha512-HOil5aFtme37dVQTB6M34G95kPM3MMuqSmIRVCC52eKV+Y/tGSqw9P3rWhlAx6A+mz+MoX+XxsGsNJbaI5qCgQ==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -14960,6 +14969,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.0.tgz",
+      "integrity": "sha512-q2yemJeg6gw/YixRlRnVx6IRJWZD6fonnfZhN1JIOhV2iJCPeRNSH3V1ISwHf+JWcESzLC3BOLD1T07tmO5dmg==",
+      "dependencies": {
+        "@remix-run/router": "1.15.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.0.tgz",
+      "integrity": "sha512-z2w+M4tH5wlcLmH3BMMOMdrtrJ9T3oJJNsAlBJbwk+8Syxd5WFJ7J5dxMEW0/GEXD1BBis4uXRrNIz3mORr0ag==",
+      "dependencies": {
+        "@remix-run/router": "1.15.0",
+        "react-router": "6.22.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,24 +1,15 @@
-import logo from './logo.svg';
 import './App.css';
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route} from 'react-router-dom';
+import { Formation } from './components/Formation';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <Router>
+      <Routes>
+        <Route path="/" exact element={<Formation />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/src/components/Formation.css
+++ b/src/components/Formation.css
@@ -1,0 +1,23 @@
+.FormationGrid {
+    display : flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.Formation {
+    border : 1px solid black;
+}
+
+.createPlayer {
+    display : flex;
+    flex-direction : row;
+    align-items : center;
+    justify-content: center;
+}
+
+.createPlayerButton {
+    border : 1px solid black;
+    border-radius : 5rem;
+    margin : 5px;
+}

--- a/src/components/Formation.js
+++ b/src/components/Formation.js
@@ -1,0 +1,95 @@
+import "./Formation.css";
+import { Player } from "./Player";
+import { useRef, useEffect, useState } from "react";
+
+export function Formation() {
+
+    const canvasRef = useRef(null);
+    const stageWidth = 1200;
+    const stageHeight = 600;
+    const [playerList, setPlayerList] = useState([]);
+
+    const [xposition, setXposition] = useState(0);
+    const [yposition, setYposition] = useState(0);
+
+    const handleXposition = (event) => {
+      setXposition(event.target.value);
+    };
+
+    const handleYposition = (event) => {
+        setYposition(event.target.value);
+    };
+
+    const addPlayer = () => {
+        const player = new Player(stageWidth, stageHeight, 30, xposition, yposition);
+        setPlayerList(prevList => [...prevList, player]);
+    };
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        const ctx = canvas.getContext('2d');
+        canvas.width = stageWidth;
+        canvas.height = stageHeight;
+
+        const animate = () => {
+            ctx.clearRect(0, 0, stageWidth, stageHeight);
+            if (playerList.length > 0) {
+                playerList.forEach(player => {
+                    player.draw(ctx);
+                });
+            }
+
+            drawLines(ctx, playerList);
+
+            requestAnimationFrame(animate);
+        };
+
+        const drawLines = (ctx, players) => {
+            ctx.strokeStyle = 'blue';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            players.forEach((player, index) => {
+                if (index === 0) {
+                    ctx.moveTo(player.x, player.y);
+                } else {
+                    ctx.lineTo(player.x, player.y);
+                }
+            });
+            ctx.closePath();
+            ctx.stroke();
+        };
+
+        animate();
+        console.log(playerList);
+
+        return () => cancelAnimationFrame(animate);
+    }, [stageWidth, stageHeight, playerList]);
+
+    return (
+        <div className = "FormationGrid">
+            This is a formation grid.
+            <canvas ref={canvasRef} className="Formation"></canvas>
+            <div className = "createPlayer">
+                x-position : 
+                <input
+                    type="number"
+                    value={xposition}
+                    onChange={handleXposition}
+                />
+                px
+                y-position : 
+                <input
+                    type="number"
+                    value={yposition}
+                    onChange={handleYposition}
+                />
+                px
+                <div className = "createPlayerButton" onClick = {addPlayer}>
+                    생성하기
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default Formation;

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -1,0 +1,62 @@
+export class Player {
+    constructor(stageWidth, stageHeight, radius, x, y) {
+        this.stageWidth = parseInt(stageWidth);
+        this.stageHeight = parseInt(stageHeight);
+        this.radius = parseInt(radius);
+        this.x = this.checkBound(parseInt(stageWidth), parseInt(radius), parseInt(x));
+        this.y = this.checkBound(parseInt(stageHeight), parseInt(radius), parseInt(y));
+
+        this.isDragging = false;
+        this.prevX = 0;
+        this.prevY = 0;
+    }
+
+    draw(ctx) {
+        ctx.fillStyle = 'red';
+        ctx.strokeStyle = 'black';
+        ctx.lineWidth = 2;
+
+        ctx.beginPath();
+        ctx.arc(this.x, this.y, this.radius, 0, 2*Math.PI);
+        ctx.fill();
+        ctx.stroke();
+    }
+
+    // Down mouse event.
+    onMouseDown(event) {
+        this.isDragging = true;
+        this.prevX = event.clientX;
+        this.prevY = event.clientY;
+    }
+
+    // Move mouse event (drag).
+    onMouseMove(event) {
+        if (this.isDragging) {
+            const deltaX = event.clientX - this.prevX;
+            const deltaY = event.clientY - this.prevY;
+            this.x += deltaX;
+            this.y += deltaY;
+            this.prevX = event.clientX;
+            this.prevY = event.clientY;
+        }
+    }
+
+    // Up mouse event.
+    onMouseUp() {
+        this.isDragging = false;
+    }
+
+    // Check bound and place ball at the right place.
+    checkBound( restrictLength, radius, position ) {
+        
+        if (position <= radius) {
+            return radius;
+        }
+        else if ((position + radius) >= restrictLength) {
+            return restrictLength - radius;
+        }
+        else {
+            return position;
+        }
+    }
+}


### PR DESCRIPTION
## 변경 사항 요약

: 축구 선수를 필드의 특정 위치에 표시하고, 선수 간 선(닫힌 도형)을 그릴 수 있습니다.

## 변경 사항 상세 내역

: canvas에서 x, y 위치를 통해 축구 선수를 필드의 특정 위치에 생성할 수 있고, 생성과 동시에 선수들을 각 꼭짓점으로 하는 다각형을 형성할 수 있습니다.

## 구현 이미지
![image](https://github.com/sgn08050/project1_soccer_frontend/assets/70854569/a33a8e20-3153-4d70-89d6-696e51b95a26)


## 비고 
드래그 시 플레이어 이동 및 위치 표시 기능을 구현할 예정입니다.
